### PR TITLE
chore: use `nodejs20`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -136,5 +136,5 @@ outputs:
     description: "The tag applied to the built image"
 
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
Node.js 16 is depreciated in github actions: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20

This should remove the annotations warning each time this is run. 

FWIW, other actions are treating this versioning as a major release. 
